### PR TITLE
Enable lowercase type names in GraphQL schema to properly render

### DIFF
--- a/codegen/field.go
+++ b/codegen/field.go
@@ -452,7 +452,7 @@ func (f *Field) GoNameUnexported() string {
 }
 
 func (f *Field) ShortInvocation() string {
-	return fmt.Sprintf("%s().%s(%s)", f.Object.Definition.Name, f.GoFieldName, f.CallArgs())
+	return fmt.Sprintf("%s().%s(%s)", strings.Title(f.Object.Definition.Name), f.GoFieldName, f.CallArgs())
 }
 
 func (f *Field) ArgsFunc() string {

--- a/codegen/generated!.gotpl
+++ b/codegen/generated!.gotpl
@@ -32,7 +32,7 @@ type Config struct {
 type ResolverRoot interface {
 {{- range $object := .Objects -}}
 	{{ if $object.HasResolvers -}}
-		{{$object.Name}}() {{$object.Name}}Resolver
+		{{ucFirst $object.Name}}() {{ucFirst $object.Name}}Resolver
 	{{ end }}
 {{- end }}
 }
@@ -46,7 +46,7 @@ type DirectiveRoot struct {
 type ComplexityRoot struct {
 {{ range $object := .Objects }}
 	{{ if not $object.IsReserved -}}
-		{{ $object.Name|go }} struct {
+		{{ucFirst $object.Name|go }} struct {
 		{{ range $_, $fields := $object.UniqueFields }}
 			{{- $field := index $fields 0 -}}
 			{{ if not $field.IsReserved -}}
@@ -60,7 +60,7 @@ type ComplexityRoot struct {
 
 {{ range $object := .Objects -}}
 	{{ if $object.HasResolvers }}
-		type {{$object.Name}}Resolver interface {
+		type {{ucFirst $object.Name}}Resolver interface {
 		{{ range $field := $object.Fields -}}
 			{{- if $field.IsResolver }}
 				{{- $field.GoFieldName}}{{ $field.ShortResolverDeclaration }}

--- a/codegen/object.go
+++ b/codegen/object.go
@@ -46,7 +46,7 @@ func (b *builder) buildObject(typ *ast.Definition) (*Object, error) {
 		Stream:             typ == b.Schema.Subscription,
 		Directives:         dirs,
 		ResolverInterface: types.NewNamed(
-			types.NewTypeName(0, b.Config.Exec.Pkg(), typ.Name+"Resolver", nil),
+			types.NewTypeName(0, b.Config.Exec.Pkg(), strings.Title(typ.Name)+"Resolver", nil),
 			nil,
 			nil,
 		),

--- a/example/config/generated.go
+++ b/example/config/generated.go
@@ -37,6 +37,7 @@ type ResolverRoot interface {
 	Mutation() MutationResolver
 	Query() QueryResolver
 	Todo() TodoResolver
+	Role() RoleResolver
 }
 
 type DirectiveRoot struct {
@@ -62,6 +63,11 @@ type ComplexityRoot struct {
 	User struct {
 		FullName func(childComplexity int) int
 		ID       func(childComplexity int) int
+		Role     func(childComplexity int) int
+	}
+
+	Role struct {
+		Name func(childComplexity int) int
 	}
 }
 
@@ -73,6 +79,9 @@ type QueryResolver interface {
 }
 type TodoResolver interface {
 	ID(ctx context.Context, obj *Todo) (string, error)
+}
+type RoleResolver interface {
+	Name(ctx context.Context, obj *UserRole) (string, error)
 }
 
 type executableSchema struct {
@@ -157,6 +166,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.User.ID(childComplexity), true
+
+	case "User.role":
+		if e.complexity.User.Role == nil {
+			break
+		}
+
+		return e.complexity.User.Role(childComplexity), true
+
+	case "role.name":
+		if e.complexity.Role.Name == nil {
+			break
+		}
+
+		return e.complexity.Role.Name(childComplexity), true
 
 	}
 	return 0, false
@@ -250,6 +273,12 @@ input NewTodo {
 @goModel(model:"github.com/99designs/gqlgen/example/config.User") {
   id: ID!
   name: String! @goField(name:"FullName")
+  role: role!
+}
+
+type role
+@goModel(model:"github.com/99designs/gqlgen/example/config.UserRole") {
+    name: String!
 }
 `, BuiltIn: false},
 }
@@ -718,6 +747,41 @@ func (ec *executionContext) _User_name(ctx context.Context, field graphql.Collec
 	res := resTmp.(string)
 	fc.Result = res
 	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _User_role(ctx context.Context, field graphql.CollectedField, obj *User) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "User",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Role, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(UserRole)
+	fc.Result = res
+	return ec.marshalNrole2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐUserRole(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql.CollectedField, obj *introspection.Directive) (ret graphql.Marshaler) {
@@ -1803,6 +1867,41 @@ func (ec *executionContext) ___Type_ofType(ctx context.Context, field graphql.Co
 	return ec.marshalO__Type2ᚖgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐType(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _role_name(ctx context.Context, field graphql.CollectedField, obj *UserRole) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "role",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   true,
+		IsResolver: true,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Role().Name(rctx, obj)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -1992,6 +2091,11 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "name":
 			out.Values[i] = ec._User_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "role":
+			out.Values[i] = ec._User_role(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -2236,6 +2340,42 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 			out.Values[i] = ec.___Type_inputFields(ctx, field, obj)
 		case "ofType":
 			out.Values[i] = ec.___Type_ofType(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var roleImplementors = []string{"role"}
+
+func (ec *executionContext) _role(ctx context.Context, sel ast.SelectionSet, obj *UserRole) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, roleImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("role")
+		case "name":
+			field := field
+			out.Concurrently(i, func() (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._role_name(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
+				return res
+			})
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -2604,6 +2744,10 @@ func (ec *executionContext) marshalN__TypeKind2string(ctx context.Context, sel a
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNrole2githubᚗcomᚋ99designsᚋgqlgenᚋexampleᚋconfigᚐUserRole(ctx context.Context, sel ast.SelectionSet, v UserRole) graphql.Marshaler {
+	return ec._role(ctx, sel, &v)
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {

--- a/example/config/model.go
+++ b/example/config/model.go
@@ -5,8 +5,13 @@ import "fmt"
 type User struct {
 	ID                  string
 	FirstName, LastName string
+	Role                UserRole
 }
 
 func (user *User) FullName() string {
 	return fmt.Sprintf("%s %s", user.FirstName, user.LastName)
+}
+
+type UserRole struct {
+	RoleName string
 }

--- a/example/config/user.graphql
+++ b/example/config/user.graphql
@@ -2,4 +2,10 @@ type User
 @goModel(model:"github.com/99designs/gqlgen/example/config.User") {
   id: ID!
   name: String! @goField(name:"FullName")
+  role: role!
+}
+
+type role
+@goModel(model:"github.com/99designs/gqlgen/example/config.UserRole") {
+    name: String!
 }

--- a/example/config/user.resolvers.go
+++ b/example/config/user.resolvers.go
@@ -1,0 +1,20 @@
+package config
+
+// This file will be automatically regenerated based on the schema, any resolver implementations
+// will be copied through when generating and any unknown code will be moved to the end.
+
+import (
+	"context"
+)
+
+func (r *roleResolver) Name(ctx context.Context, obj *UserRole) (string, error) {
+	if obj == nil {
+		return "", nil
+	}
+	return obj.RoleName, nil
+}
+
+// Role returns RoleResolver implementation.
+func (r *Resolver) Role() RoleResolver { return &roleResolver{r} }
+
+type roleResolver struct{ *Resolver }

--- a/plugin/resolvergen/resolver.go
+++ b/plugin/resolvergen/resolver.go
@@ -94,7 +94,7 @@ func (m *Plugin) generatePerSchema(data *codegen.Data) error {
 			}
 
 			rewriter.MarkStructCopied(templates.LcFirst(o.Name) + templates.UcFirst(data.Config.Resolver.Type))
-			rewriter.GetMethodBody(data.Config.Resolver.Type, o.Name)
+			rewriter.GetMethodBody(data.Config.Resolver.Type, strings.Title(o.Name))
 			files[fn].Objects = append(files[fn].Objects, o)
 		}
 		for _, f := range o.Fields {

--- a/plugin/resolvergen/resolver.gotpl
+++ b/plugin/resolvergen/resolver.gotpl
@@ -26,8 +26,8 @@
 {{ end }}
 
 {{ range $object := .Objects -}}
-	// {{$object.Name}} returns {{ $object.ResolverInterface | ref }} implementation.
-	func (r *{{$.ResolverType}}) {{$object.Name}}() {{ $object.ResolverInterface | ref }} { return &{{lcFirst $object.Name}}{{ucFirst $.ResolverType}}{r} }
+	// {{ucFirst $object.Name}} returns {{ $object.ResolverInterface | ref }} implementation.
+	func (r *{{$.ResolverType}}) {{ucFirst $object.Name}}() {{ $object.ResolverInterface | ref }} { return &{{lcFirst $object.Name}}{{ucFirst $.ResolverType}}{r} }
 {{ end }}
 
 {{ range $object := .Objects -}}


### PR DESCRIPTION
The difficulty with lowercased type names is that in go code any lowercased name is not exported.
This change makes the names title case for go code while preserving the proper case when interacting with the GraphQL schema.

Describe your PR and link to any relevant issues. 

I have:
 - [ ] Added tests covering the bug / feature (see [testing](https://github.com/99designs/gqlgen/blob/master/TESTING.md))
 - [ ] Updated any relevant documentation (see [docs](https://github.com/99designs/gqlgen/tree/master/docs/content))
